### PR TITLE
Refactor dates with `date-fns` instead of moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@mdx-js/react": "^1.6.4",
     "@styled-icons/feather": "^10.0.0",
-    "moment": "^2.26.0",
+    "date-fns": "^2.14.0",
     "next": "^9.4.2",
     "nprogress": "^0.2.0",
     "prism-react-renderer": "^1.1.1",

--- a/src/components/postInit.tsx
+++ b/src/components/postInit.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Head from 'next/head';
+import { format } from 'date-fns';
 
 import { findPost } from '../utils/posts';
 import { rhythm } from '../utils/typography';
@@ -17,7 +18,7 @@ const PostInit = ({ id }: Props): JSX.Element => {
       </Head>
       <h1 style={{ marginBottom: '0' }}>{post.title}</h1>
       <span style={{ fontSize: rhythm(1 / 2) }}>
-        {post.createdAt.format('MMMM D, YYYY')}
+        {format(post.createdAt, 'MMMM d, yyyy')}
       </span>
       <p />
     </>

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -3,8 +3,8 @@ export default [
     id: 'ruined-expectations-from-unist',
     title: 'Ruined expectations from UNIST',
     description:
-      'Rants about what I like and (mostly) dislike about my university',
-    tags: ['en'],
+      'Rants about what I like and (mostly) dislike about my university.',
+    tags: ['en', 'rants', 'university'],
     createdAt: '2020-05-26',
     public: true,
   },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { NextPage } from 'next';
 import Link from 'next/link';
 import styled from 'styled-components';
+import { format } from 'date-fns';
 import { getPosts } from '../utils/posts';
 import { rhythm } from '../utils/typography';
 
@@ -32,7 +33,7 @@ const Index: NextPage = () => {
             </Link>
           </Title>
           <span style={{ fontSize: rhythm(1 / 2) }}>
-            {post.createdAt.format('MMMM D, YYYY')}
+            {format(post.createdAt, 'MMMM d, yyyy')}
           </span>
           <Description>
             {'> '}

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -34,7 +34,7 @@ function filterPublic(feed: PostMeta[]): PostMeta[] {
 }
 
 function sortPosts(feed: Post[]): Post[] {
-  feed.sort((a, b) => compareAsc(a, b));
+  feed.sort((a, b) => compareAsc(a.createdAt, b.createdAt));
   return feed;
 }
 

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import { compareAsc } from 'date-fns';
 import allPosts from '../feed';
 
 export interface PostMeta {
@@ -14,8 +14,8 @@ export interface PostMeta {
 export interface Post {
   id: string;
   title: string;
-  createdAt: moment.Moment;
-  updatedAt: moment.Moment;
+  createdAt: Date;
+  updatedAt: Date;
   description: string;
   tags: string[];
 }
@@ -23,8 +23,8 @@ export interface Post {
 function parsePosts(feed: PostMeta[]): Post[] {
   return feed.map((p) => ({
     ...p,
-    createdAt: moment(p.createdAt),
-    updatedAt: moment(p.updatedAt || p.createdAt),
+    createdAt: new Date(p.createdAt),
+    updatedAt: new Date(p.updatedAt || p.createdAt),
     tags: p.tags || [],
   }));
 }
@@ -34,7 +34,7 @@ function filterPublic(feed: PostMeta[]): PostMeta[] {
 }
 
 function sortPosts(feed: Post[]): Post[] {
-  feed.sort((a, b) => (a.createdAt.isBefore(b.createdAt) ? 1 : -1));
+  feed.sort((a, b) => compareAsc(a, b));
   return feed;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2787,6 +2787,11 @@ data-uri-to-buffer@3.0.0:
   dependencies:
     buffer-from "^1.1.1"
 
+date-fns@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
+  integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
+
 debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -5063,11 +5068,6 @@ modularscale@^1.0.2:
   integrity sha1-So8TrzKl5SFPxuLPxSkGSr/X2Hc=
   dependencies:
     lodash.isnumber "^3.0.0"
-
-moment@^2.26.0:
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"
-  integrity sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
* Shave off around `100kb` for each page.
* Maximum Potential First Input Delay is down to `150ms` on Lighthouse Audit.